### PR TITLE
Bug Fix: Configuration file name can contain multiple dots.

### DIFF
--- a/Source/AnomalyDetection.py
+++ b/Source/AnomalyDetection.py
@@ -36,7 +36,7 @@ class AnomAnalWindow(QtWidgets.QDialog):
 
         # If there is an AnomAnal file, open it for later access
         # to file-specific parameters
-        anomAnalFileName,_ = ConfigFile.filename.split('.')
+        anomAnalFileName = os.path.splitext(ConfigFile.filename)[0]
         self.anomAnalFileName = anomAnalFileName + '_anoms.csv'
         fp = os.path.join('Config',self.anomAnalFileName)
         if os.path.exists(fp):

--- a/Source/Controller.py
+++ b/Source/Controller.py
@@ -596,8 +596,8 @@ class Controller:
                 #   ConfigFile.settings to reflect the appropriate parameterizations for this 
                 #   particular file. If no parameter file exists, or this SAS file is not in it, 
                 #   then fall back on the current ConfigFile.settings.
-                
-                anomAnalFileName,_ = ConfigFile.filename.split('.')
+
+                anomAnalFileName = os.path.splitext(ConfigFile.filename)[0]
                 anomAnalFileName = anomAnalFileName + '_anoms.csv'
                 fp = os.path.join('Config',anomAnalFileName)
                 if os.path.exists(fp):


### PR DESCRIPTION
For example a configuration file can be named "pySAS002.EXPORTSNA.cfg" whereas before a file name with multiple dots (".") was causing an error.