### PR TITLE
TRIOS L1BQC filtering: solve issue #173

### DIFF
--- a/Source/ProcessL1bqc.py
+++ b/Source/ProcessL1bqc.py
@@ -430,6 +430,14 @@ class ProcessL1bqc:
                     Utilities.filterData(esGroup,badTimes,'L1AQC')
                     Utilities.filterData(liGroup,badTimes,'L1AQC')
                     Utilities.filterData(ltGroup,badTimes,'L1AQC')
+                    
+                    # print('badTimes', len(badTimes))
+                    # for dname in esGroup.datasets:
+                    #     ds = esGroup.getDataset(dname).data
+                    #     print(dname, np.shape(ds))
+                        
+                    # # esGroup.datasets.remove('BACK_ES')
+                    # #    del esGroup.datasets['BACK_ES']
 
                 if py6sGroup is not None:
                     Utilities.filterData(py6sGroup,badTimes)


### PR DESCRIPTION
in L1BQC filtering Trios data have to be managed differently from seabird. The Back and Cal datasets have different number of rows (255 instead of the number of acquisition). To this day the filtering was wrongly apply to Cal & Back and then the 2 dataset were reset back to their original values. But in this example we filter more than 255 points which cause the index error. 

Now the Back & Cal dataset are deleted before filtering and then reset at the end of the filtering, I did not find any better way, due to the filtering being applied to all dataset of a group at once (this work for Seabird but not for Trios).