### PR TITLE
UQAR: Add core HyperCP support for Satlantic R08W sensor types

### DIFF
--- a/Source/CalibrationFile.py
+++ b/Source/CalibrationFile.py
@@ -33,9 +33,9 @@ class CalibrationFile:
         #print("CalibrationFile.read()")
         (_, filename) = os.path.split(f.name)
         self.name = filename
-        if filename.lower().startswith('hed') or filename.lower().startswith('hld'):
+        if filename.lower().startswith('hed') or filename.lower().startswith('hld') or filename.lower().startswith('pld'):
             self.frameType = 'ShutterDark'
-        elif filename.lower().startswith('hse') or filename.lower().startswith('hsl'):
+        elif filename.lower().startswith('hse') or filename.lower().startswith('hsl') or filename.lower().startswith('hpl'):
             self.frameType = 'ShutterLight'
         else:
             self.frameType = 'Not Required'
@@ -52,8 +52,10 @@ class CalibrationFile:
             if len(line) == 0:
                 continue
             if line.startswith("#"):
-                if filename[0:3] in ['HSL','HED','HLD','HSE']:
+                if filename[0:3] in ['HSL','HED','HLD','HSE','HPL','PLD']: # NOTE: HPL and PLD added for HOCR type R08W used as R03A; immersion factor in calibration files set to 1.0
                     # NOTE: Highly presumptuous format requirement here
+                    #if filename[0:3] in ['HPL','PLD']:
+                    #    logging.writeLogFileAndPrint(f"WARNING : calibration file {filename}: is for sensor type R08W. Make sure immersion factor is set to 1 in the calibration file.")
                     if line.startswith("# 20"):
                         try:
                             # This will update with each new calibration date until the last/latest date
@@ -100,6 +102,8 @@ class CalibrationFile:
     # Returns the sensor type
     def getSensorType(self):
         for cd in self.data:
+            # ADD FOR DEBUG
+            print("Sensor type:", cd.type)
             if cd.type == "ES" or \
                cd.type == "LI" or \
                cd.type == "LT" or \
@@ -231,6 +235,8 @@ class CalibrationFile:
             instrumentId.startswith("SATHLD") or \
             instrumentId.startswith("SATHSE") or \
             instrumentId.startswith("SATHSL") or \
+            instrumentId.startswith("SATHPL") or \
+            instrumentId.startswith("SATPLD") or \
             instrumentId.startswith("SATPYR") or \
             instrumentId.startswith("SATNAV") or \
             instrumentId.startswith("$GPRMC") or \

--- a/Source/ProcessL1aSeaBird.py
+++ b/Source/ProcessL1aSeaBird.py
@@ -85,7 +85,11 @@ class ProcessL1aSeaBird:
         for gp in root.groups:
             if gp.id.startswith("HLD"):
                 hld += 1
+            if gp.id.startswith("PLD"):
+                hld += 1
             if gp.id.startswith("HSL"):
+                hsl += 1
+            if gp.id.startswith("HPL"):
                 hsl += 1
             if gp.id.startswith("HSE"):
                 hse += 1

--- a/Source/ProcessL1aqc.py
+++ b/Source/ProcessL1aqc.py
@@ -156,7 +156,17 @@ class ProcessL1aqc:
                     gp.id = "LI_DARK"
                 if cf.sensorType == "LT":
                     gp.id = "LT_DARK"
+            if gp.id.startswith("PLD"):
+                if cf.sensorType == "LI":
+                    gp.id = "LI_DARK"
+                if cf.sensorType == "LT":
+                    gp.id = "LT_DARK"
             if gp.id.startswith("HSL"):
+                if cf.sensorType == "LI":
+                    gp.id = "LI_LIGHT"
+                if cf.sensorType == "LT":
+                    gp.id = "LT_LIGHT"
+            if gp.id.startswith("HPL"):
                 if cf.sensorType == "LI":
                     gp.id = "LI_LIGHT"
                 if cf.sensorType == "LT":

--- a/Source/ProcessL1b.py
+++ b/Source/ProcessL1b.py
@@ -756,7 +756,7 @@ class ProcessL1b:
                 and not gp.id.startswith('PYROMETER') \
                     and 'FrameType' in gp.attributes:
                 if gp.attributes["FrameType"] == "Not Required":
-                    logging.writeLogFileAndPrint(f'ERROR: Check the FrameType for {sensorType}')
+                    logging.writeLogFileAndPrint(f'ERROR: Check the FrameType for {sensorType}, Current type is  {gp.attributes["FrameType"]}. \n Check the FrameType in the CFG file for each calibration file.')
                     break
 
                 if gp.attributes["FrameType"] == "ShutterDark" and gp.getDataset(sensorType):


### PR DESCRIPTION
Hello HyperCP Team,

This Pull Request provides the core updates required to properly read and process radiometry data from Satlantic/SeaBird sensors utilizing the R08W frame/sensor format specifications. IMPORTANT: users should be awarre that those HOCR are build for in-water operation. The main difference is their larger FOV of 8° compare to 3° for R03A type.  To use R08W for Lt or Li, one needs to make the immersion factor in the calibration files are set to 1.0.  The calibration files should also change the LU to LT (water) or LI (sky). 

Key Changes:
Updated Source/CalibrationFile.py and device parsing routines to recognize and map R08W header blocks and coefficients.
Adjusted Source/ProcessL1aSeaBird.py 
Adjusted Source/ProcessL1aqc.py

Not related to R08W:  Added more information in Source/ProcessL1b.py when frameType is not well set in the cfg file to ensure proper frame type identification during the dark/light offset corrections. I got stuck a few time on this error and took me a while to figure out the problem. 

Testing Environment:
These updates were implemented and successfully tested on a MacBook Pro running Python 3.11 within the official standard Conda environment.Tested using both the pySAS and SolarTracker sample datasets provided in the repository to ensure no regressions were introduced to the legacy structures, as well as live field data collected from the St. Lawrence Estuary aboard the Amundsen research vessel.

Please let me know if any further refactoring is required to ease the upcoming merge into the dev (v1.2.17) branch!